### PR TITLE
fix: : add claw user to docker group for sandbox access

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 >
 > - OpenClaw's internal operations and tool execution
 > - Code or commands run by authenticated users
-> - Subagent isolation (configurable via sandboxing - see below)
+
 
 A containerized deployment of [OpenClaw](https://openclaw.ai/) deployment secured by Pomerium's zero-trust identity-aware proxy.
 
@@ -80,7 +80,7 @@ OpenClaw is distributed as an npm package and doesn't provide an official Docker
 
 - OpenClaw CLI installed from npm
 - SSH server with Pomerium User CA integration
-- Git and Docker CLI for agent operations
+- Git for agent operations
 - Persistent workspace mounted at `/claw/workspace`
 
 The gateway runs on an internal Docker network with none of those ports exposed to the internet. All access is proxied through Pomerium, which provides identity-aware, zero-trust access control. SSH traffic via port 2200 and HTTPS traffic via port 443 are secured with context-based authorization policies that verify user identity and device posture before granting access. See the [deployment guide](https://docs.pomerium.com/guides/openclaw-gateway) for detailed architecture and security considerations. Where you deploy, port 22 will typically be open by default. Once Pomerium is configured, you can disable direct port 22 access (recommended), ensuring all SSH connections are authenticated and authorized through Pomerium's policy engine.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,6 @@ services:
       - ./openclaw-data/config:/claw
       - ./openclaw-data/workspace:/claw/workspace
       - ./openclaw-data/pomerium-ssh:/var/lib/pomerium:ro # For Pomerium User CA key (read-only)
-      - /var/run/docker.sock:/var/run/docker.sock
     init: true
     restart: unless-stopped
     networks:

--- a/openclaw-data/config/.openclaw/openclaw.json
+++ b/openclaw-data/config/.openclaw/openclaw.json
@@ -19,20 +19,6 @@
       "subagents": {
         "maxConcurrent": 8
       },
-      "sandbox": {
-        "mode": "non-main",
-        "workspaceAccess": "none",
-        "scope": "session",
-        "docker": {
-          "network": "bridge",
-          "dns": [
-            "1.1.1.1",
-            "1.0.0.1",
-            "8.8.8.8",
-            "8.8.4.4"
-          ]
-        }
-      },
       "compaction": {
         "memoryFlush": {
           "enabled": true
@@ -54,25 +40,6 @@
       "enabled": true,
       "allowFrom": {
         "webchat": []
-      }
-    },
-    "sandbox": {
-      "tools": {
-        "deny": [
-          "exec",
-          "process",
-          "browser",
-          "canvas",
-          "nodes",
-          "gateway",
-          "cron",
-          "telegram",
-          "whatsapp",
-          "discord",
-          "slack",
-          "signal",
-          "imessage"
-        ]
       }
     }
   },

--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -1,14 +1,8 @@
 FROM node:24-slim
 
-# Install git, openssh-server, iproute2 (for ip command), jq, and Docker CLI
+# Install git, openssh-server, iproute2 (for ip command), and jq
 RUN apt-get update && \
-  apt-get install -y git openssh-server iproute2 jq ca-certificates curl sudo && \
-  install -m 0755 -d /etc/apt/keyrings && \
-  curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
-  chmod a+r /etc/apt/keyrings/docker.asc && \
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list && \
-  apt-get update && \
-  apt-get install -y docker-ce-cli && \
+  apt-get install -y git openssh-server iproute2 jq sudo && \
   rm -rf /var/lib/apt/lists/*
 
 # Create claw user with home directory at /claw

--- a/openclaw/entrypoint.sh
+++ b/openclaw/entrypoint.sh
@@ -32,20 +32,6 @@ su - claw -c "openclaw config set gateway.controlUi.allowedOrigins '$UPDATED'" 2
   echo "Warning: Could not set allowedOrigins (config may not exist yet)"
 }
 
-# Add sandbox images for OpenClaw
-# See: https://github.com/openclaw/openclaw/issues/4807
-if ! docker image inspect openclaw-sandbox:bookworm-slim >/dev/null 2>&1; then
-  echo "Building sandbox base image openclaw-sandbox:bookworm-slim..."
-  docker pull debian:bookworm-slim
-  docker tag debian:bookworm-slim openclaw-sandbox:bookworm-slim
-fi
-
-if ! docker image inspect openclaw-sandbox-browser:bookworm-slim >/dev/null 2>&1; then
-  echo "Building sandbox browser image openclaw-sandbox-browser:bookworm-slim..."
-  docker pull debian:bookworm-slim
-  docker tag debian:bookworm-slim openclaw-sandbox-browser:bookworm-slim
-fi
-
 # Ensure claw user owns its home directory contents
 chown -R claw:claw /claw
 


### PR DESCRIPTION
Removed sandboxing support because although a good idea, the Docker sock mounted in the container gives access to the host.

Leave it up to the user to make those decisions instead by referencing https://docs.openclaw.ai

Fixes #1
