### PR TITLE
fix(docker): fix trustedProxies JSON generation and permissions

### DIFF
--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
 # Create claw user with home directory at /claw
 RUN useradd -m -d /claw -s /bin/bash claw && \
   mkdir -p /claw/workspace && \
+  mkdir -p /claw/.openclaw && \
   chown -R claw:claw /claw
 
 # Configure SSH

--- a/openclaw/entrypoint.sh
+++ b/openclaw/entrypoint.sh
@@ -1,13 +1,16 @@
 #!/bin/sh
 set -e
 
+# Ensure claw user owns its home directory contents
+chown -R claw:claw /claw
+
 # Auto-detect Docker network subnets and configure trusted proxies
-# Detects all non-loopback IPv4 interfaces
-SUBNETS=$(ip -o -f inet addr show | grep -v "127.0.0.1" | awk '{print $4}' | tr '\n' '|')
+SUBNETS=$(ip -o -f inet addr show | grep -v "127.0.0.1" | awk '{print $4}' | paste -sd ',' -)
+
 if [ -n "$SUBNETS" ]; then
   echo "Detected Docker networks: $SUBNETS"
-  # Convert to JSON array format
-  JSON_ARRAY=$(echo "$SUBNETS" | sed 's/|/","/g' | sed 's/^/["/' | sed 's/$/"]/')
+  JSON_ARRAY=$(echo "$SUBNETS" | jq -R 'split(",") | map(select(length > 0))')
+
   su - claw -c "openclaw config set gateway.trustedProxies \"$JSON_ARRAY\" --json" 2>/dev/null || {
     echo "Warning: Could not set trustedProxies (config may not exist yet)"
   }
@@ -15,7 +18,7 @@ else
   echo "Warning: Could not detect any Docker networks"
 fi
 
-# Configure allowed origins (requires POMERIUM_CLUSTER_DOMAIN)
+# Configure allowed origins
 if [ -z "$POMERIUM_CLUSTER_DOMAIN" ]; then
   echo "Error: POMERIUM_CLUSTER_DOMAIN environment variable is required"
   exit 1
@@ -24,16 +27,12 @@ fi
 NEW_ORIGIN="https://openclaw.$POMERIUM_CLUSTER_DOMAIN"
 echo "Configuring allowed origins for $NEW_ORIGIN"
 
-# Get current allowedOrigins, append if not already present
 CURRENT=$(su - claw -c "openclaw config get gateway.controlUi.allowedOrigins" 2>/dev/null || echo "[]")
 UPDATED=$(echo "$CURRENT" | jq -c --arg origin "$NEW_ORIGIN" 'if index($origin) then . else . + [$origin] end')
 
 su - claw -c "openclaw config set gateway.controlUi.allowedOrigins '$UPDATED'" 2>/dev/null || {
   echo "Warning: Could not set allowedOrigins (config may not exist yet)"
 }
-
-# Ensure claw user owns its home directory contents
-chown -R claw:claw /claw
 
 # Start SSH daemon (must run as root)
 /usr/sbin/sshd


### PR DESCRIPTION
This pull request introduces improvements to the Docker setup and entrypoint script for the OpenClaw application. The main changes focus on enhancing directory ownership, improving network subnet detection and formatting, and streamlining the configuration of allowed origins.

Improvements to directory setup and ownership:

* Ensured that the `claw` user owns all contents of its home directory by adding a `chown` command at the start of the `openclaw/entrypoint.sh` script.
* Created the `.openclaw` directory within `/claw` during Docker image build to support application requirements.

Enhancements to network detection and configuration:

* Improved detection and formatting of Docker network subnets in `openclaw/entrypoint.sh` by switching from pipe-separated to comma-separated values and using `jq` for robust JSON array creation.

Streamlining allowed origins configuration:

* Refactored allowed origins setup in `openclaw/entrypoint.sh` by removing redundant directory ownership commands and ensuring the new origin is only appended if not already present.

Closes #4