### PR TITLE
fix: cleaned up Docker setup

### DIFF
--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
 # Create claw user with home directory at /claw
 RUN useradd -m -d /claw -s /bin/bash claw && \
   mkdir -p /claw/workspace && \
+  mkdir -p /claw/.openclaw && \
   chown -R claw:claw /claw
 
 # Configure SSH

--- a/openclaw/entrypoint.sh
+++ b/openclaw/entrypoint.sh
@@ -1,30 +1,19 @@
 #!/bin/sh
 set -e
 
-# Auto-detect Docker network subnets and configure trusted proxies
-# Detects all non-loopback IPv4 interfaces
-SUBNETS=$(ip -o -f inet addr show | grep -v "127.0.0.1" | awk '{print $4}' | tr '\n' '|')
-if [ -n "$SUBNETS" ]; then
-  echo "Detected Docker networks: $SUBNETS"
-  # Convert to JSON array format
-  JSON_ARRAY=$(echo "$SUBNETS" | sed 's/|/","/g' | sed 's/^/["/' | sed 's/$/"]/')
-  su - claw -c "openclaw config set gateway.trustedProxies \"$JSON_ARRAY\" --json" 2>/dev/null || {
-    echo "Warning: Could not set trustedProxies (config may not exist yet)"
-  }
-else
-  echo "Warning: Could not detect any Docker networks"
-fi
+# Ensure claw user owns its home directory contents
+chown -R claw:claw /claw
 
-# Configure allowed origins (requires POMERIUM_CLUSTER_DOMAIN)
+# Configure allowed origins
 if [ -z "$POMERIUM_CLUSTER_DOMAIN" ]; then
   echo "Error: POMERIUM_CLUSTER_DOMAIN environment variable is required"
   exit 1
 fi
 
+# Change the sub domain if you don't name your from route in Pomerium "openclaw.$POMERIUM_CLUSTER_DOMAIN"
 NEW_ORIGIN="https://openclaw.$POMERIUM_CLUSTER_DOMAIN"
 echo "Configuring allowed origins for $NEW_ORIGIN"
 
-# Get current allowedOrigins, append if not already present
 CURRENT=$(su - claw -c "openclaw config get gateway.controlUi.allowedOrigins" 2>/dev/null || echo "[]")
 UPDATED=$(echo "$CURRENT" | jq -c --arg origin "$NEW_ORIGIN" 'if index($origin) then . else . + [$origin] end')
 
@@ -32,11 +21,8 @@ su - claw -c "openclaw config set gateway.controlUi.allowedOrigins '$UPDATED'" 2
   echo "Warning: Could not set allowedOrigins (config may not exist yet)"
 }
 
-# Ensure claw user owns its home directory contents
-chown -R claw:claw /claw
-
 # Start SSH daemon (must run as root)
 /usr/sbin/sshd
 
 # Run openclaw as claw user
-exec su - claw -c "openclaw gateway --bind lan --allow-unconfigured"
+exec su - claw -c "openclaw gateway"


### PR DESCRIPTION
This pull request introduces improvements to the Docker setup and entrypoint script for the OpenClaw application. The main changes focus on enhancing directory ownership, and removing auto detection of trusted proxy IP ranges. This should be set manually by the user instead.

Closes #4